### PR TITLE
Swap out `zip-extractor` release for a branch which resolves `cargo audit` failures.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.*"
 reqwest = { version = "0.11.*", features = ["blocking"] }
-zip-extract = { version = "^0.1.1", features = ["deflate"] }
+
+zip-extract.git = "https://github.com/nathan-at-least/zip-extract.git"
+zip-extract.branch = "resolve-RUSTSEC-2018-0017"
+zip-extract.features = ["deflate"]
 
 [dev-dependencies]
 tonic-build = "0.8.*"


### PR DESCRIPTION
Note, while `cargo audit` now reports no errors or warnings, I do not believe it is recursively checking the unreleased branch of `zip-extractor`. However, the PR in question attests to `cargo audit` succeeding for that branch. See:

https://github.com/MCOfficer/zip-extract/pull/12

This PR resolves #3 in a brittle way, since it replaces the dependency of `git-extractor` from a release to a git branch. It may be a useful interim solution until `git-extractor` publishes a new release with the PR above merged.