### PR TITLE
Ensure we use `zip-extract = "^0.1.2"` which fixes a `cargo-audit` failure, see #3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.*"
 reqwest = { version = "0.11.*", features = ["blocking"] }
-zip-extract = { version = "^0.1.1", features = ["deflate"] }
+zip-extract = { version = "^0.1.2", features = ["deflate"] }
 
 [dev-dependencies]
 tonic-build = "0.8.*"


### PR DESCRIPTION
This PR bumps the version requirement on `zip-extract` to a new release which addresses issue #3.

New users of `protoc-fetcher` _without_ this PR should be fine, since dependency resolution on `^0.1.1` will fetch the newer `0.1.2` which avoids the audit failure. Existing projects with pinned `Cargo.lock` will need to run `cargo update`.

Incorporating this PR will simply ensure any new users or anyone who updates `protoc-fetcher` _cannot_ hit the audit failure.