### PR TITLE
Use zip crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "protoc-fetcher"
 authors = ["Joe Dahlquist <joe@arcanyx.com>"]
-categories = ["compilers", "development-tools::build-utils", "parsing", "web-programming", "network-programming"]
+categories = [
+  "compilers",
+  "development-tools::build-utils",
+  "parsing",
+  "web-programming",
+  "network-programming",
+]
 description = "Fetches official Protocol Buffer compiler (protoc) releases for use in build scripts"
 documentation = "https://docs.rs/protoc-fetcher"
 edition = "2021"
@@ -14,9 +20,9 @@ version = "0.1.1"
 
 [dependencies]
 anyhow = "1.0.81"
-reqwest = { version = "0.11.27", features = ["blocking"] }
+reqwest = { version = "0.12.9", features = ["blocking"] }
 zip = "2.2.0"
 
 [dev-dependencies]
 tempfile = "3.14.0"
-tonic-build = "0.11.0"
+tonic-build = "0.12.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ version = "0.1.1"
 [dependencies]
 anyhow = "1.0.81"
 reqwest = { version = "0.11.27", features = ["blocking"] }
-zip-extract = { version = "0.1.3", features = ["deflate"] }
+zip = "2.2.0"
 
 [dev-dependencies]
+tempfile = "3.14.0"
 tonic-build = "0.11.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,3 +143,19 @@ fn get_protoc_version(protoc_path: &Path) -> anyhow::Result<String> {
     let version = String::from_utf8(Command::new(&protoc_path).arg("--version").output()?.stdout)?;
     Ok(version)
 }
+
+#[cfg(test)]
+mod test {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_protoc_runs_without_error() {
+        let version = "28.0";
+        let temp_dir = tempdir().unwrap();
+
+        let result = protoc(version, temp_dir.path());
+        assert!(result.is_ok());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Download official protobuf compiler (protoc) releases with a single command, pegged to the
 //! version of your choice.
 
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use reqwest::StatusCode;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -76,7 +76,7 @@ fn ensure_protoc_installed(version: &str, install_dir: &Path) -> anyhow::Result<
 
 fn download_protoc(protoc_dir: &Path, release_name: &str, version: &str) -> anyhow::Result<()> {
     let archive_url = protoc_release_archive_url(release_name, version);
-    let response = reqwest::blocking::get(archive_url)?;
+    let response = reqwest::blocking::get(&archive_url)?;
     if response.status() != StatusCode::OK {
         bail!(
             "Error downloading release archive: {} {}",
@@ -88,7 +88,20 @@ fn download_protoc(protoc_dir: &Path, release_name: &str, version: &str) -> anyh
 
     fs::create_dir_all(protoc_dir)?;
     let cursor = Cursor::new(response.bytes()?);
-    zip_extract::extract(cursor, protoc_dir, false)?;
+
+    let mut archive = zip::ZipArchive::new(cursor).with_context(|| {
+        format!(
+            "Failed to create ZipArchive from downloaded archive (from {})",
+            archive_url
+        )
+    })?;
+    archive.extract(protoc_dir).with_context(|| {
+        format!(
+            "Failed to extract archive to {:?} (from {})",
+            protoc_dir, archive_url
+        )
+    })?;
+
     println!("Extracted archive.");
 
     let protoc_path = protoc_dir.join("bin/protoc");


### PR DESCRIPTION
Swap out zip-extract for zip

I was getting strange permissions errors previously (when downloading to user cache, and user home). Somewhere  during zip_extract, where files were being written from the archive to disk, towards the end, it would hit a Permissions error. I'm on Ubuntu 24.04, but have been able to reproduce on a separate docker container on 22.04, and on WSL.

I couldn't figure out what was going on, so I tried using a different zip extract crate and the problem has gone away.