### PR TITLE
Support mulitple processes on same download dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.1"
 [dependencies]
 anyhow = "1.0.81"
 reqwest = { version = "0.12.9", features = ["blocking"] }
-zip-extract = { version = "0.1.3", features = ["deflate"] }
+zip = "2.2.1"
 
 [dev-dependencies]
 googletest = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,6 @@ reqwest = { version = "0.11.27", features = ["blocking"] }
 zip-extract = { version = "0.1.3", features = ["deflate"] }
 
 [dev-dependencies]
+googletest = "0.12.0"
+tempfile = "3.14.0"
 tonic-build = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ version = "0.1.1"
 
 [dependencies]
 anyhow = "1.0.81"
-reqwest = { version = "0.11.27", features = ["blocking"] }
+reqwest = { version = "0.12.9", features = ["blocking"] }
 zip-extract = { version = "0.1.3", features = ["deflate"] }
 
 [dev-dependencies]
 googletest = "0.12.0"
 tempfile = "3.14.0"
-tonic-build = "0.11.0"
+tonic-build = "0.12.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Download official protobuf compiler (protoc) releases with a single command, pegged to the
 //! version of your choice.
 
-use anyhow::{bail, Context};
+use anyhow::{bail, Context as _};
 use reqwest::StatusCode;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -90,7 +90,14 @@ fn download_protoc(protoc_dir: &Path, release_name: &str, version: &str) -> anyh
     fs::create_dir_all(protoc_dir)
         .with_context(|| format!("Failed to create dir: {:?}", protoc_dir))?;
     let cursor = Cursor::new(response.bytes()?);
-    zip_extract::extract(cursor, protoc_dir, false).with_context(|| {
+
+    let mut archive = zip::ZipArchive::new(cursor).with_context(|| {
+        format!(
+            "Failed to create ZipArchive from downloaded archive (from {})",
+            archive_url
+        )
+    })?;
+    archive.extract(protoc_dir).with_context(|| {
         format!(
             "Failed to extract archive to {:?} (from {})",
             protoc_dir, archive_url


### PR DESCRIPTION
Thanks @jdahlq for this crate!

I have a cargo workspace where a few crates are all using protoc-fetcher in their build.rs script. Some of them depend on other crates too.
When I run cargo build on the workspace, or on a crate that has a dependency also using protoc-fetcher, protoc-fetcher runs in multiple instances at the same time on the same download directory (i.e. only one download directory for the cargo workspace)

I took a while to figure out what the issue was, but it's that there's multiple writes happening to the same dir at the same time.
I've added a test for this case and have implemented a lock file to solve the issue.

Other changes I implemented while figuring out the issue in this PR:
use `zip` crate instead of `zip-extract`
updated dependencies
add additional context to failures with anyhow::Context, since I was seeing "Permissions Error" with no context, that made debugging difficult.